### PR TITLE
Fix undefined error caused by clearing font list

### DIFF
--- a/src/Component/Symbolizer/TextEditor/TextEditor.tsx
+++ b/src/Component/Symbolizer/TextEditor/TextEditor.tsx
@@ -134,7 +134,11 @@ export class TextEditor extends React.Component<TextEditorProps> {
       onSymbolizerChange
     } = this.props;
     const symbolizer = _cloneDeep(this.props.symbolizer);
-    symbolizer.font = value.length > 0 ? value : undefined;
+    if (value.length) {
+      symbolizer.font = value;
+    } else {
+      delete symbolizer.font;
+    }
     if (onSymbolizerChange) {
       onSymbolizerChange(symbolizer);
     }


### PR DESCRIPTION
## Description

When clear seleted fonts, an undefined error throws by https://github.com/geostyler/geostyler-sld-parser/blob/b07d6e71553ca2c99a15a60e7d1bf63df091cefd/src/SldStyleParser.ts#L1509, beacuse `textSymbolizer.font` was assigned with `undefined` .

https://github.com/geostyler/geostyler-sld-parser/blob/master/src/SldStyleParser.ts#L1509

 https://github.com/geostyler/geostyler-sld-parser/blob/b07d6e71553ca2c99a15a60e7d1bf63df091cefd/src/SldStyleParser.ts#L1509

## Related issues or pull requests

## Pull request type

Please check the type of change your PR introduces:

<!-- put an x between the square brackets to check an item, like so: [x] -->

- [x] Bugfix
- [ ] Feature
- [ ] Dependency updates
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe)
- [ ] I am unsure (we'll look into it together)

## Do you introduce a breaking change?

- [ ] Yes
- [x] No
- [ ] I am unsure (no worries, we'll find out)

## Checklist

- [x] I understand and agree that the changes in this PR will be licensed under the [BSD 2-Clause License](https://github.com/geostyler/geostyler/blob/master/)
- [x] I have followed the [guidelines for contributing](https://github.com/geostyler/geostyler/blob/master/CONTRIBUTING.md)
- [x] The proposed change fits to the content of the [code of conduct](https://github.com/geostyler/geostyler/blob/master/CODE_OF_CONDUCT.md)
- [x] I have added or updated tests and documentation, and the test suite passes (run `npm test` locally)
- [ ] I'm lost; why do I have to check so many boxes? Please help!
